### PR TITLE
Add zsh theme name to zgen load command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you're using [`antigen`](https://github.com/zsh-users/antigen), you can test 
 
 ### zgen
 
-If you're using `zgen`, add them to your `init.zsh` with `zgen load sobolevn/sobole-zsh-theme`.
+If you're using `zgen`, add them to your `init.zsh` with `zgen load sobolevn/sobole-zsh-theme sobole`.
 
 ### Manual
 


### PR DESCRIPTION
I was having problems getting zgen to load the sobole theme. I found that I had to also include the filename `sobole` in the load command. Thanks for this awesome theme!