### PR TITLE
Prevent line separator on top of terminal.

### DIFF
--- a/sobole.zsh-theme
+++ b/sobole.zsh-theme
@@ -164,15 +164,15 @@ if [[ -z "$SOBOLE_DONOTTOUCH_HIGHLIGHTING" ]]; then
 fi
 
 preexec() {
-  if [[ $2 == "clear" ]]; then
-	  ADD_LINE_SEPARATOR="false"
+  if [[ "$2" == 'clear' ]]; then
+	  ADD_LINE_SEPARATOR='false'
   else
-    ADD_LINE_SEPARATOR="true"
+    ADD_LINE_SEPARATOR='true'
   fi
 }
 
 precmd() {
-  if [[ $ADD_LINE_SEPARATOR == "true" ]]; then
+  if [[ "$ADD_LINE_SEPARATOR" == 'true' ]]; then
     print
   fi
 }

--- a/sobole.zsh-theme
+++ b/sobole.zsh-theme
@@ -18,8 +18,7 @@ else
   CARETCOLOR="black"
 fi
 
-PROMPT='
-$(current_venv)$(user_info)$(current_dir) $(vcs_prompt_info)
+PROMPT='$(current_venv)$(user_info)$(current_dir) $(vcs_prompt_info)
 $(current_caret) '
 
 PROMPT2='. '
@@ -163,3 +162,17 @@ if [[ -z "$SOBOLE_DONOTTOUCH_HIGHLIGHTING" ]]; then
     ZSH_HIGHLIGHT_STYLES[path]='fg=white,underline'
   fi
 fi
+
+preexec() {
+  if [[ $2 == "clear" ]]; then
+	  ADD_LINE_SEPARATOR="false"
+  else
+    ADD_LINE_SEPARATOR="true"
+  fi
+}
+
+precmd() {
+  if [[ $ADD_LINE_SEPARATOR == "true" ]]; then
+    print
+  fi
+}


### PR DESCRIPTION
This PR checks if the shell is either first run or after executing a `clear` command, no line separator will be printed.

![image](https://user-images.githubusercontent.com/34796192/199629770-d8ff5e68-7720-447f-bf38-6e9d5430b2db.png)